### PR TITLE
Default "bare" option

### DIFF
--- a/lib/sproutcore-coffeescript/builders/coffeescript.rb
+++ b/lib/sproutcore-coffeescript/builders/coffeescript.rb
@@ -7,7 +7,7 @@ module SC
     end
 
     def readlines(src_path)
-      ";" + ::CoffeeScript.compile(super)
+      ";" + ::CoffeeScript.compile(super, :bare => true)
     rescue NameError
       begin
         require "coffee-script"


### PR DESCRIPTION
Hi!

I added the "bare" option as default. I found it less distractive when the compiler outputs something more resembling to the "ordinary" way sproutcore's .js files were written. In some cases the closure wrapper provided by the compiler can be confusing to debug. (especially when `main.coffee` is used instead of `main.js`)
